### PR TITLE
Fix for symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Crossbar.io : https://github.com/crossbario
 
 * install [aktos-dcs-lib](https://github.com/ceremcem/aktos-dcs-lib)
 
-  `git clone https://github.com/ceremcem/aktos-dcs-lib aktos-dcs-lib-cca`      
+  `git clone https://github.com/ceremcem/aktos-dcs-lib aktos-dcs-lib`      
 
 * install [Node.js](http://nodejs.org/)
 * install global dependencies:

--- a/manual-test/python-messaging/aktos_dcs_lib
+++ b/manual-test/python-messaging/aktos_dcs_lib
@@ -1,1 +1,1 @@
-../../../aktos-dcs-lib-cca/aktos_dcs_lib/
+../../../aktos-dcs-lib/aktos_dcs_lib


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/283117/11993611/cde18404-aa3b-11e5-8636-e98d32ce09ad.png)

which can be trouble for new supporters. when trying to run keypad_simulator.py python gives a not module error. 